### PR TITLE
Correct hash_final use across PHP versions. 

### DIFF
--- a/zipstream.php
+++ b/zipstream.php
@@ -419,8 +419,14 @@ class ZipStream {
 
       # close file and finalize crc
       fclose($fh);
-      $crc = unpack('V', hash_final($hash_ctx, true));
-      $crc = $crc[1];
+      
+      if (version_compare(PHP_VERSION, '5.2.6', '>')) {
+        $crc = hexdec(hash_final($hash_ctx));
+      }else{
+        $crc = unpack('V', hash_final($hash_ctx, true));
+        $crc = $crc[1];
+      }
+      
     } else {
       die("unknown large_file_method: $meth_str");
     }


### PR DESCRIPTION
If you see this http://3v4l.org/3cF9I - the behaviour of `hash*` changed in PHP 5.2.7 and up, so we need to change how the CRCs are created in 5.2.7+

This took me a good long while to hunt down :smile: but fixes the crc in versions of PHP greater than 5.2.6.  
Currently there is no problem in 5.1.2 - 5.2.6 but any newer than that and things break - I am running 5.5.14 for instance though and the CRC's generated with the `hash*` methods are incorrect.
