### PR TITLE
Fixes large file store method hash_file for php > 5.2.6

### DIFF
--- a/zipstream.php
+++ b/zipstream.php
@@ -399,8 +399,12 @@ class ZipStream {
     if ($meth_str == 'store') {
       # store method
       $meth = 0x00;
-      $crc  = unpack('V', hash_file($algo, $path, true));
-      $crc = $crc[1];
+      if (version_compare(PHP_VERSION, '5.2.6', '>')) {
+        $crc = hexdec(hash_file($algo, $path));
+      } else {
+        $crc = unpack('V', hash_file($algo, $path, true));
+        $crc = $crc[1];
+      }
     } elseif ($meth_str == 'deflate') {
       # deflate method
       $meth = 0x08;


### PR DESCRIPTION
This is similar to the previous PR.  hash_file's behaviour has changed as well

Here is a little [3v4l proof](http://3v4l.org/WTLTe) of the change. 
