### PR TITLE
Allow add stream from a remote resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 clover.xml
+phpunit.xml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ require 'vendor/autoload.php';
 # create a new zipstream object
 $zip = new ZipStream\ZipStream('example.zip');
 
-# create a file named 'hello.txt' 
+# create a file named 'hello.txt'
 $zip->addFile('hello.txt', 'This is the contents of hello.txt');
 
 # add a file named 'some_image.jpg' from a local file 'path/to/image.jpg'
@@ -37,7 +37,13 @@ $zip->addFileFromPath('some_image.jpg', 'path/to/image.jpg');
 # add a file named 'goodbye.txt' from an open stream resource
 $fp = tmpfile();
 fwrite($fp, 'The quick brown fox jumped over the lazy dog.');
+rewind($fp); // Put the file pointer back to the start (fwrite() moved it forward)
 $zip->addFileFromStream('goodbye.txt', $fp);
+fclose($fp);
+
+# add a big image named 'big-remote-image.jpg' from an open remote stream resource, without compromising memory.
+$fp = fopen('http://example.com/big/image.jpg');
+zip->addFileFromStream('big-remote-image.jpg', $fp);
 fclose($fp);
 
 # finish the zip stream

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -159,11 +159,13 @@ class ZipStreamTest extends PHPUnit_Framework_TestCase {
 
 		$streamExample = fopen('php://temp', 'w+');
 		fwrite($streamExample, "Sample String Data");
+		fseek($streamExample, SEEK_SET, 0); // rewind to the start, otherwise there will be no content.
 		$zip->addFileFromStream('sample.txt', $streamExample);
 		fclose($streamExample);
 
 		$streamExample2 = fopen('php://temp', 'w+');
 		fwrite($streamExample2, "More Simple Sample Data");
+		fseek($streamExample2, SEEK_SET, 0); // rewind to the start, otherwise there will be no content.
 		$zip->addFileFromStream('test/sample.txt', $streamExample2);
 		fclose($streamExample2);
 

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -159,13 +159,13 @@ class ZipStreamTest extends PHPUnit_Framework_TestCase {
 
 		$streamExample = fopen('php://temp', 'w+');
 		fwrite($streamExample, "Sample String Data");
-		fseek($streamExample, SEEK_SET, 0); // rewind to the start, otherwise there will be no content.
+		rewind($streamExample); // rewind to the start, otherwise there will be no content.
 		$zip->addFileFromStream('sample.txt', $streamExample);
 		fclose($streamExample);
 
 		$streamExample2 = fopen('php://temp', 'w+');
 		fwrite($streamExample2, "More Simple Sample Data");
-		fseek($streamExample2, SEEK_SET, 0); // rewind to the start, otherwise there will be no content.
+		rewind($streamExample2); // rewind to the start, otherwise there will be no content.
 		$zip->addFileFromStream('test/sample.txt', $streamExample2);
 		fclose($streamExample2);
 


### PR DESCRIPTION
Backward Compatibility: Yes.
Tests passes:                  Yes.
New Feature:                  Yes. Able to download any sized remote resource from a stream.
New Tests added:           No. Using tests already in place since they cover the re-implementation.

Hi there.
This is a re-implementation of `addFileFromStream`, to allow the use of a stream pointing to a remote resource. This should let us download files of any size without compromising memory.

The way it works is by making use of the Zip header 'data descriptor' See https://en.wikipedia.org/wiki/Zip_(file_format).

In short, we send the initial Local File Header with an empty crc, len and zlen. Then we loop the stream and read in chunks and send the data as soon as it arrives.

Right afterwards, we send the special Data Descriptor header informing the actual crc, len and zlen. Then we register the file data for the central directory record for later. The total record len is the sum of the initial Local File Header len, plus the data sent (zlen), plus the Data Descriptor len.

I went one step further and did a moderate refactor of some methods, and added a bunch of constants. Sorry if this is too much. However since I see you guys are already working on a major refactor, I won't mind if you don't end merging this PR :) In any case, I'll be thrilled to make this PR better as per your needs.

Let me know your thoughts.
Best.

cc: @donatj.