### PR TITLE
Fix CRC calculation for addFileFromStream

### DIFF
--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -718,7 +718,7 @@ class ZipStream
             $this->send($zdata);
 
             // Update crc and data lengths.
-            hash_update($hash_ctx, $zdata);
+            hash_update($hash_ctx, $data);
             $len += strlen($data);
             $zlen += strlen($zdata);
         }


### PR DESCRIPTION
This fixes the CRC calculation for data added from streams. It should be calculating the CRC over the uncompressed data, not the compressed data. `unzip -t file.zip` on linux can be used to verify the integrity of zipped data.

The following short program can can be used to demonstrate the issue. Without this patch, the CRC verification fails because it calculates the CRC over the compressed data instead of the original data.

```php
<?php

require_once 'vendor/autoload.php';

use ZipStream\ZipStream;

$zipPath = '/tmp/file.zip';

$inputFile = fopen('php://memory', 'r+');
fwrite($inputFile, 'testing');
rewind($inputFile);

$fd = fopen($zipPath, 'w');
try {
    $zip = new ZipStream('output.zip', [
        ZipStream::OPTION_OUTPUT_STREAM => $fd,
    ]);

    $zip->addFileFromStream('test.txt', $inputFile);
    $zip->finish();
}
finally {
    fclose($fd);
}

system("unzip -t $zipPath");
unlink($zipPath);
```