### PR TITLE
Revert ZIP_VERSION_MADE_BY to its original value

### DIFF
--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -57,7 +57,7 @@ use ZipStream\Option\Version;
  */
 class ZipStream
 {
-    const ZIP_VERSION_MADE_BY = 0x031E; // 3.00 on Unix
+    const ZIP_VERSION_MADE_BY = 0x603; // 3.00 on Unix
 
     const FILE_HEADER_SIGNATURE = 0x04034b50;
     const CDR_FILE_SIGNATURE = 0x02014b50;


### PR DESCRIPTION
as it is causing some file permission issues on extracted files as discussed in #84 & #76 

Fixes #76 
Fixes #84 