### PR TITLE
Fix memory leak

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -425,9 +425,9 @@ class File
     /**
      * Send CDR record for specified file.
      *
-     * @return void
+     * @return string
      */
-    public function addCdrFile(): void
+    public function getCdrFile(): string
     {
         $name = static::filterFilename($this->name);
 
@@ -461,11 +461,7 @@ class File
         // pack fields, then append name and comment
         $header = ZipStream::packFields($fields);
 
-        $data = $header . $name . $footer . $comment;
-        $this->zip->send($data);
-
-        // increment cdr offset
-        $this->zip->cdr_ofs = $this->zip->cdr_ofs->add(Bigint::init(strlen($data)));
+        return $header . $name . $footer . $comment;
     }
 
     /**

--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -325,8 +325,9 @@ class ZipStream
     public function finish(): void
     {
         // add trailing cdr file records
-        foreach ($this->files as $file) {
-            $file->addCdrFile();
+        foreach ($this->files as $cdrFile) {
+            $this->send($cdrFile);
+            $this->cdr_ofs = $this->cdr_ofs->add(Bigint::init(strlen($cdrFile)));
         }
 
         // Add 64bit headers (if applicable)
@@ -552,6 +553,6 @@ class ZipStream
     {
         $file->ofs = $this->ofs;
         $this->ofs = $this->ofs->add($file->getTotalLength());
-        $this->files[] = $file;
+        $this->files[] = $file->getCdrFile();
     }
 }


### PR DESCRIPTION
Priorto that fix, when I was adding 100 times the same file into a zip,
I had this kind of memory consumption:

```
php zip.php
100/100 [============================] 100%  1 sec/1 sec  28.0 MiB
````

After the fix I obtain a constant memory consumption, whatever the
number of times I add the file:

```
php zip.php
100/100 [============================] 100%  1 sec/1 sec  4.0 MiB
````