### PR TITLE
Fix incorrect default value of httpHeaderCallback. Fix #85

### DIFF
--- a/src/Option/Archive.php
+++ b/src/Option/Archive.php
@@ -40,9 +40,11 @@ final class Archive
      */
     private $sendHttpHeaders = false;
     /**
+     * The method called to send headers
+     *
      * @var Callable
      */
-    private $httpHeaderCallback = 'method';
+    private $httpHeaderCallback = 'header';
     /**
      * Enable Zip64 extension, supporting very large
      * archives (any size > 4 GB or file count > 64k)


### PR DESCRIPTION
With the default value, setting sendHttpHeaders to true would result in
a crash (error 500). With this change, the 'headers()' function is
called and all is well, no need to call setHttpHeaderCallback('header')