### PR TITLE
Fix overwrite of last-modified timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Honor last-modified timestamps set via `ZipStream\Option\File::setTime()`
+
 ## [1.0.0] - 2019-04-17
 
 ### Breaking changes

--- a/src/Option/File.php
+++ b/src/Option/File.php
@@ -27,7 +27,7 @@ final class File
     public function defaultTo(Archive $archiveOptions): void
     {
         $this->deflateLevel = $this->deflateLevel ?: $archiveOptions->getDeflateLevel();
-        $this->time = new DateTime();
+        $this->time = $this->time ?: new DateTime();
     }
 
     /**

--- a/test/bug/BugHonorFileTimeTest.php
+++ b/test/bug/BugHonorFileTimeTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace BugHonorFileTimeTest;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use ZipStream\Option\{
+    Archive,
+    File
+};
+use ZipStream\ZipStream;
+
+use function fopen;
+
+/**
+ * Asserts that specified last-modified timestamps are not overwritten when a
+ * file is added
+ */
+class BugHonorFileTimeTest extends TestCase
+{
+    public function testHonorsFileTime(): void
+    {
+        $archiveOpt = new Archive();
+        $fileOpt = new File();
+        $expectedTime = new DateTime('2019-04-21T19:25:00-0800');
+
+        $archiveOpt->setOutputStream(fopen('php://memory', 'wb'));
+        $fileOpt->setTime(clone $expectedTime);
+
+        $zip = new ZipStream(null, $archiveOpt);
+
+        $zip->addFile('sample.txt', 'Sample', $fileOpt);
+
+        $zip->finish();
+
+        $this->assertEquals($expectedTime, $fileOpt->getTime());
+    }
+}


### PR DESCRIPTION
At the moment it is not possible to set the last-modified timestamp before adding a file because `ZipStream\Option\File::defaultTo()` always overwrites it with the current time.

As an example, the following snippet does not set the timestamp of *sample.txt* to *2019-01-01 00:00*:
```php
$options = new \ZipStream\Option\File();
$zip = new \ZipStream\ZipStream();

$options->setTime(new \DateTime('2019-01-01 00:00'));

$zip->addFile('sample.txt', 'Sample', $options);
```

This little change should fix that.

(This is my first contribution. Please forgive me if it's horrible.)