### PR TITLE
Update .travis.yml for php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 php:
   - 7.1
   - 7.2
+  - 7.3
 install: composer install
 script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 after_script:


### PR DESCRIPTION
PHP 7.3 has been out for a while.

Updates .travis.yml to run against it.