### PR TITLE
Fix docs regarding output of HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ Here's a simple example:
 # Autoload the dependencies
 require 'vendor/autoload.php';
 
+# enable output of HTTP headers
+$options = new ZipStream\Option\Archive();
+$options->setSendHttpHeaders(true);
+
 # create a new zipstream object
-$zip = new ZipStream\ZipStream('example.zip');
+$zip = new ZipStream\ZipStream('example.zip', $options);
 
 # create a file named 'hello.txt'
 $zip->addFile('hello.txt', 'This is the contents of hello.txt');

--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -163,9 +163,10 @@ class ZipStream
      *
      * Notes:
      *
-     * If you do not set a filename, then this library _DOES NOT_ send HTTP
-     * headers by default.  This behavior is to allow software to send its
-     * own headers (including the filename), and still use this library.
+     * In order to let this library send HTTP headers, a filename must be given
+     * _and_ the option `sendHttpHeaders` must be `true`. This behavior is to
+     * allow software to send its own headers (including the filename), and
+     * still use this library.
      */
     public function __construct(?string $name = null, ?ArchiveOptions $opt = null)
     {


### PR DESCRIPTION
Since commit fbe6ba5 headers are only automatically sent if both the
output filename *and* the `sendHttpHeaders` option are set. This
commit changes the docs to reflect that.

PR as requested in issue #107.