### PR TITLE
Only close self opened streams

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -115,8 +115,10 @@ class File
         } else {
             $this->method = $this->zip->opt->getLargeFileMethod();
 
-            $stream = new DeflateStream(fopen($path, 'rb'));
+            $res = fopen($path, 'rb');
+            $stream = new DeflateStream($res);
             $this->processStream($stream);
+            fclose($res);
         }
     }
 

--- a/src/File.php
+++ b/src/File.php
@@ -115,10 +115,9 @@ class File
         } else {
             $this->method = $this->zip->opt->getLargeFileMethod();
 
-            $res = fopen($path, 'rb');
-            $stream = new DeflateStream($res);
+            $stream = new DeflateStream(fopen($path, 'rb'));
             $this->processStream($stream);
-            fclose($res);
+            $stream->close();
         }
     }
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -22,11 +22,6 @@ class Stream implements StreamInterface
         $this->stream = $stream;
     }
 
-    public function __destruct()
-    {
-        $this->close();
-    }
-
     /**
      * Closes the stream and any underlying resources.
      *


### PR DESCRIPTION
Hi, thanks for the library!

I am using addFileFromStream and was suprised to see the stream resources being closed afterwards. I feel the library should only do this for streams it opens itself. Since Stream is not fopen'ing itself, it shoudn't fclose either, it is responsibility of the user.