### PR TITLE
use mbstring polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": ">= 7.1",
-    "ext-mbstring": "*",
+    "symfony/polyfill-mbstring": "^1.0",
     "psr/http-message": "^1.0",
     "myclabs/php-enum": "^1.5"
   },


### PR DESCRIPTION
In order to make the library a bit more portable, instead of requiring `ext-mbstring` to be enabled, rely on mbstring polyfill when the extension is missing.

In this pull request, I've replaced explicit dependency on `ext-mbstring` with `symfony/polyfill-mbstring` instead.