### PR TITLE
Prevent triggering of notice when no output buffer to flush

### DIFF
--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -462,8 +462,14 @@ class ZipStream
         fwrite($this->opt->getOutputStream(), $str);
 
         if ($this->opt->isFlushOutput()) {
+            // flush output buffer if it is on and flushable
+            $status = ob_get_status();
+            if (isset($status['flags']) && ($status['flags'] & PHP_OUTPUT_HANDLER_FLUSHABLE)) {
+                ob_flush();
+            }
+
+            // Flush system buffers after flushing userspace output buffer
             flush();
-            ob_flush();
         }
     }
 

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -557,4 +557,30 @@ class ZipStreamTest extends TestCase
         $this->assertStringEqualsFile($tmpDir . '/sample.txt', 'Sample String Data');
         $this->assertStringEqualsFile($tmpDir . '/test/sample.txt', 'More Simple Sample Data');
     }
+
+    public function testCreateArchiveWithOutputBufferingOffAndFlushOptionSet(): void
+    {
+        // WORKAROUND (1/2): remove phpunit's output buffer in order to run test without any buffering
+        ob_end_flush();
+        $this->assertEquals(0, ob_get_level());
+
+        [$tmp, $stream] = $this->getTmpFileStream();
+
+        $options = new ArchiveOptions();
+        $options->setOutputStream($stream);
+        $options->setFlushOutput(true);
+
+        $zip = new ZipStream(null, $options);
+
+        $zip->addFile('sample.txt', 'Sample String Data');
+
+        $zip->finish();
+        fclose($stream);
+
+        $tmpDir = $this->validateAndExtractZip($tmp);
+        $this->assertStringEqualsFile($tmpDir . '/sample.txt', 'Sample String Data');
+
+        // WORKAROUND (2/2): add back output buffering so that PHPUnit doesn't complain that it is missing
+        ob_start();
+    }
 }


### PR DESCRIPTION
When no output buffer is on, the call to `ob_flush()` can trigger the PHP notice `ob_flush(): failed to flush buffer. No buffer to flush`. In order to skip the call to `ob_flush()`, but still call `flush()` a few checks was added to ensure a flushable buffer is indeed on before trying to flush. A test case was also added.