### PR TITLE
Add ability to set instance of StreamInterface as output stream

### DIFF
--- a/src/Option/Archive.php
+++ b/src/Option/Archive.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace ZipStream\Option;
 
+use Psr\Http\Message\StreamInterface;
+
 final class Archive
 {
     const DEFAULT_DEFLATE_LEVEL = 6;
@@ -104,7 +106,7 @@ final class Archive
     private $deflateLevel = 6;
 
     /**
-     * @var resource
+     * @var StreamInterface|resource
      */
     private $outputStream;
 
@@ -228,7 +230,7 @@ final class Archive
     }
 
     /**
-     * @return resource
+     * @return StreamInterface|resource
      */
     public function getOutputStream()
     {
@@ -236,7 +238,7 @@ final class Archive
     }
 
     /**
-     * @param resource $outputStream
+     * @param StreamInterface|resource $outputStream
      */
     public function setOutputStream($outputStream): void
     {

--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -459,7 +459,13 @@ class ZipStream
         }
         $this->need_headers = false;
 
-        fwrite($this->opt->getOutputStream(), $str);
+        $outputStream = $this->opt->getOutputStream();
+
+        if ($outputStream instanceof StreamInterface) {
+            $outputStream->write($str);
+        } else {
+            fwrite($outputStream, $str);
+        }
 
         if ($this->opt->isFlushOutput()) {
             // flush output buffer if it is on and flushable

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -10,6 +10,7 @@ use ZipStream\File;
 use ZipStream\Option\Archive as ArchiveOptions;
 use ZipStream\Option\File as FileOptions;
 use ZipStream\Option\Method;
+use ZipStream\Stream;
 use ZipStream\ZipStream;
 
 /**
@@ -496,6 +497,33 @@ class ZipStreamTest extends TestCase
         $zip->addFileFromPsr7Stream('sample.json', $response->getBody(), $fileOptions);
         $zip->finish();
         fclose($stream);
+
+        $tmpDir = $this->validateAndExtractZip($tmp);
+
+        $files = $this->getRecursiveFileList($tmpDir);
+        $this->assertEquals(array('sample.json'), $files);
+        $this->assertStringEqualsFile($tmpDir . '/sample.json', $body);
+    }
+
+    public function testAddFileFromPsr7StreamWithOutputToPsr7Stream(): void
+    {
+        [$tmp, $resource] = $this->getTmpFileStream();
+        $psr7OutputStream = new Stream($resource);
+
+        $options = new ArchiveOptions();
+        $options->setOutputStream($psr7OutputStream);
+
+        $zip = new ZipStream(null, $options);
+
+        $body = 'Sample String Data';
+        $response = new Response(200, [], $body);
+
+        $fileOptions = new FileOptions();
+        $fileOptions->setMethod(Method::STORE());
+
+        $zip->addFileFromPsr7Stream('sample.json', $response->getBody(), $fileOptions);
+        $zip->finish();
+        $psr7OutputStream->close();
 
         $tmpDir = $this->validateAndExtractZip($tmp);
 

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -526,8 +526,8 @@ class ZipStreamTest extends TestCase
         $psr7OutputStream->close();
 
         $tmpDir = $this->validateAndExtractZip($tmp);
-
         $files = $this->getRecursiveFileList($tmpDir);
+
         $this->assertEquals(array('sample.json'), $files);
         $this->assertStringEqualsFile($tmpDir . '/sample.json', $body);
     }


### PR DESCRIPTION
Example:
```php
use Laminas\Diactoros\Response;
use Psr\Http\Message\ResponseInterface;
use Psr\Http\Message\StreamInterface;
use ZipStream\Option\Archive as ArchiveOptions;
use ZipStream\ZipStream;

...

public function example(StreamInterface $outputStream): ResponseInterface
{
    $options = new ArchiveOptions();
    $options->setOutputStream($outputStream);

    $zip = new ZipStream(null, $options);
    $zip->addFile('sample.txt', 'Sample String Data');
    $zip->finish();

    return new Response($outputStream, 200, [
        'Content-Type' => 'application/zip',
        'Content-Disposition' => 'attachment;filename="archive.zip"',
        'Cache-Control' => 'max-age=0',
    ]);
}
```