### PR TITLE
Add php-cs-fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.clover
 phpunit.xml
 vendor
 .phpunit.result.cache
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+/**
+ * PHP-CS-Fixer config for ZipStream-PHP
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2022 Nicolas CARPi
+ * @see https://github.com/maennchen/ZipStream-PHP
+ * @license MIT
+ * @package maennchen/ZipStream-PHP
+ */
+
+$finder = PhpCsFixer\Finder::create()
+    ->name('/\.php|\.php.dist$/')
+    ->in(['src', 'test'])
+;
+
+$config = new PhpCsFixer\Config();
+
+return $config->setRules(array(
+    '@PSR2' => true,
+    '@PHP71Migration' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'class_attributes_separation' => true,
+    'declare_strict_types' => true,
+    'dir_constant' => true,
+    'is_null' => true,
+    'no_homoglyph_names' => true,
+    'no_null_property_initialization' => true,
+    'no_php4_constructor' => true,
+    'no_unused_imports' => true,
+    'no_useless_else' => true,
+    'non_printable_character' => true,
+    'ordered_imports' => true,
+    'ordered_class_elements' => true,
+    'php_unit_construct' => true,
+    'pow_to_exponentiation' => true,
+    'psr_autoloading' => true,
+    'random_api_migration' => true,
+    'return_assignment' => true,
+    'self_accessor' => true,
+    'semicolon_after_instruction' => true,
+    'short_scalar_cast' => true,
+    'simplified_null_return' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_class_element_per_statement' => true,
+    'single_line_comment_style' => true,
+    'single_quote' => true,
+    'space_after_semicolon' => true,
+    'standardize_not_equals' => true,
+    'strict_param' => true,
+    'ternary_operator_spaces' => true,
+    'trailing_comma_in_multiline' => true,
+    'trim_array_spaces' => true,
+    'unary_operator_spaces' => true,
+    'global_namespace_import' => [
+        'import_classes' => true,
+        'import_functions' => true,
+        'import_constants' => true,
+    ],
+))
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+;

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,13 @@
     "ext-zip": "*",
     "mikey179/vfsstream": "^1.6",
     "vimeo/psalm": "^4.1",
-    "php-coveralls/php-coveralls": "^2.4"
+    "php-coveralls/php-coveralls": "^2.4",
+    "friendsofphp/php-cs-fixer": "^3.9"
+  },
+  "scripts": {
+    "test": "phpunit",
+    "lint": "php-cs-fixer fix -v",
+    "dry-lint": "php-cs-fixer fix --dry-run --stop-on-violation -v"
   },
   "autoload": {
     "psr-4": {

--- a/src/Bigint.php
+++ b/src/Bigint.php
@@ -23,22 +23,6 @@ class Bigint
     }
 
     /**
-     * Fill the bytes field with int
-     *
-     * @param int $value
-     * @param int $start
-     * @param int $count
-     * @return void
-     */
-    protected function fillBytes(int $value, int $start, int $count): void
-    {
-        for ($i = 0; $i < $count; $i++) {
-            $this->bytes[$start + $i] = $i >= PHP_INT_SIZE ? 0 : $value & 0xFF;
-            $value >>= 8;
-        }
-    }
-
-    /**
      * Get an instance
      *
      * @param int $value
@@ -58,7 +42,7 @@ class Bigint
      */
     public static function fromLowHigh(int $low, int $high): self
     {
-        $bigint = new Bigint();
+        $bigint = new self();
         $bigint->fillBytes($low, 0, 4);
         $bigint->fillBytes($high, 4, 4);
         return $bigint;
@@ -150,7 +134,7 @@ class Bigint
      * @param Bigint $other
      * @return Bigint
      */
-    public function add(Bigint $other): Bigint
+    public function add(self $other): self
     {
         $result = clone $this;
         $overflow = false;
@@ -169,5 +153,21 @@ class Bigint
             throw new OverflowException;
         }
         return $result;
+    }
+
+    /**
+     * Fill the bytes field with int
+     *
+     * @param int $value
+     * @param int $start
+     * @param int $count
+     * @return void
+     */
+    protected function fillBytes(int $value, int $start, int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $this->bytes[$start + $i] = $i >= PHP_INT_SIZE ? 0 : $value & 0xFF;
+            $value >>= 8;
+        }
     }
 }

--- a/src/DeflateStream.php
+++ b/src/DeflateStream.php
@@ -58,7 +58,7 @@ class DeflateStream extends Stream
             'comment' => $options->getComment(),
             'method' => $options->getMethod(),
             'deflateLevel' => $options->getDeflateLevel(),
-            'time' => $options->getTime()
+            'time' => $options->getTime(),
         ];
         $this->filter = stream_filter_append(
             $this->stream,

--- a/src/File.php
+++ b/src/File.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace ZipStream;
 
+use HashContext;
 use Psr\Http\Message\StreamInterface;
-use RuntimeException;
 use ZipStream\Exception\EncodingException;
 use ZipStream\Exception\FileNotFoundException;
 use ZipStream\Exception\FileNotReadableException;
@@ -15,13 +15,15 @@ use ZipStream\Option\Version;
 
 class File
 {
-    const HASH_ALGORITHM = 'crc32b';
+    public const HASH_ALGORITHM = 'crc32b';
 
-    const BIT_ZERO_HEADER = 0x0008;
-    const BIT_EFS_UTF8 = 0x0800;
+    public const BIT_ZERO_HEADER = 0x0008;
 
-    const COMPUTE = 1;
-    const SEND = 2;
+    public const BIT_EFS_UTF8 = 0x0800;
+
+    public const COMPUTE = 1;
+
+    public const SEND = 2;
 
     private const CHUNKED_READ_BLOCK_SIZE = 1048576;
 
@@ -39,6 +41,7 @@ class File
      * @var Bigint
      */
     public $len;
+
     /**
      * @var Bigint
      */
@@ -78,7 +81,7 @@ class File
     private $deflate;
 
     /**
-     * @var \HashContext
+     * @var HashContext
      */
     private $hash;
 
@@ -176,7 +179,7 @@ class File
             $this->version = Version::DEFLATE();
         }
 
-        $force = (boolean)($this->bits & self::BIT_ZERO_HEADER) &&
+        $force = (bool)($this->bits & self::BIT_ZERO_HEADER) &&
             $this->zip->opt->isEnableZip64();
 
         $footer = $this->buildZip64ExtraBlock($force);
@@ -229,6 +232,97 @@ class File
     }
 
     /**
+     * Create and send data descriptor footer for this file.
+     *
+     * @return void
+     */
+    public function addFileFooter(): void
+    {
+        if ($this->bits & self::BIT_ZERO_HEADER) {
+            // compressed and uncompressed size
+            $sizeFormat = 'V';
+            if ($this->zip->opt->isEnableZip64()) {
+                $sizeFormat = 'P';
+            }
+            $fields = [
+                ['V', ZipStream::DATA_DESCRIPTOR_SIGNATURE],
+                ['V', $this->crc],              // CRC32
+                [$sizeFormat, $this->zlen],     // Length of compressed data
+                [$sizeFormat, $this->len],      // Length of original data
+            ];
+
+            $footer = ZipStream::packFields($fields);
+            $this->zip->send($footer);
+        } else {
+            $footer = '';
+        }
+        $this->totalLength = $this->hlen->add($this->zlen)->add(Bigint::init(strlen($footer)));
+        $this->zip->addToCdr($this);
+    }
+
+    public function processStream(StreamInterface $stream): void
+    {
+        $this->zlen = new Bigint();
+        $this->len = new Bigint();
+
+        if ($this->zip->opt->isZeroHeader()) {
+            $this->processStreamWithZeroHeader($stream);
+        } else {
+            $this->processStreamWithComputedHeader($stream);
+        }
+    }
+
+    /**
+     * Send CDR record for specified file.
+     *
+     * @return string
+     */
+    public function getCdrFile(): string
+    {
+        $name = static::filterFilename($this->name);
+
+        // get attributes
+        $comment = $this->opt->getComment();
+
+        // get dos timestamp
+        $time = static::dosTime($this->opt->getTime()->getTimestamp());
+
+        $footer = $this->buildZip64ExtraBlock();
+
+        $fields = [
+            ['V', ZipStream::CDR_FILE_SIGNATURE],   // Central file header signature
+            ['v', ZipStream::ZIP_VERSION_MADE_BY],  // Made by version
+            ['v', $this->version->getValue()],      // Extract by version
+            ['v', $this->bits],                     // General purpose bit flags - data descriptor flag set
+            ['v', $this->method->getValue()],       // Compression method
+            ['V', $time],                           // Timestamp (DOS Format)
+            ['V', $this->crc],                      // CRC32
+            ['V', $this->zlen->getLowFF()],         // Compressed Data Length
+            ['V', $this->len->getLowFF()],          // Original Data Length
+            ['v', strlen($name)],                   // Length of filename
+            ['v', strlen($footer)],                 // Extra data len (see above)
+            ['v', strlen($comment)],                // Length of comment
+            ['v', 0],                               // Disk number
+            ['v', 0],                               // Internal File Attributes
+            ['V', 32],                              // External File Attributes
+            ['V', $this->ofs->getLowFF()],           // Relative offset of local header
+        ];
+
+        // pack fields, then append name and comment
+        $header = ZipStream::packFields($fields);
+
+        return $header . $name . $footer . $comment;
+    }
+
+    /**
+     * @return Bigint
+     */
+    public function getTotalLength(): Bigint
+    {
+        return $this->totalLength;
+    }
+
+    /**
      * Convert a UNIX timestamp to a DOS timestamp.
      *
      * @param int $when
@@ -241,14 +335,14 @@ class File
 
         // set lower-bound on dates
         if ($d['year'] < 1980) {
-            $d = array(
+            $d = [
                 'year' => 1980,
                 'mon' => 1,
                 'mday' => 1,
                 'hours' => 0,
                 'minutes' => 0,
-                'seconds' => 0
-            );
+                'seconds' => 0,
+            ];
         }
 
         // remove extra years from 1980
@@ -266,7 +360,6 @@ class File
 
     protected function buildZip64ExtraBlock(bool $force = false): string
     {
-
         $fields = [];
         if ($this->len->isOver32($force)) {
             $fields[] = ['P', $this->len];          // Length of original data
@@ -303,49 +396,6 @@ class File
         return ZipStream::packFields($fields);
     }
 
-    /**
-     * Create and send data descriptor footer for this file.
-     *
-     * @return void
-     */
-
-    public function addFileFooter(): void
-    {
-
-        if ($this->bits & self::BIT_ZERO_HEADER) {
-            // compressed and uncompressed size
-            $sizeFormat = 'V';
-            if ($this->zip->opt->isEnableZip64()) {
-                $sizeFormat = 'P';
-            }
-            $fields = [
-                ['V', ZipStream::DATA_DESCRIPTOR_SIGNATURE],
-                ['V', $this->crc],              // CRC32
-                [$sizeFormat, $this->zlen],     // Length of compressed data
-                [$sizeFormat, $this->len],      // Length of original data
-            ];
-
-            $footer = ZipStream::packFields($fields);
-            $this->zip->send($footer);
-        } else {
-            $footer = '';
-        }
-        $this->totalLength = $this->hlen->add($this->zlen)->add(Bigint::init(strlen($footer)));
-        $this->zip->addToCdr($this);
-    }
-
-    public function processStream(StreamInterface $stream): void
-    {
-        $this->zlen = new Bigint();
-        $this->len = new Bigint();
-
-        if ($this->zip->opt->isZeroHeader()) {
-            $this->processStreamWithZeroHeader($stream);
-        } else {
-            $this->processStreamWithComputedHeader($stream);
-        }
-    }
-
     protected function processStreamWithZeroHeader(StreamInterface $stream): void
     {
         $this->bits |= self::BIT_ZERO_HEADER;
@@ -363,7 +413,7 @@ class File
             $data = $stream->read(self::CHUNKED_READ_BLOCK_SIZE);
             $total += strlen($data);
             if ($size > 0 && $total > $size) {
-                $data = substr($data, 0 , strlen($data)-($total - $size));
+                $data = substr($data, 0, strlen($data)-($total - $size));
             }
             $this->deflateData($stream, $data, $options);
             if ($options & self::SEND) {
@@ -433,55 +483,5 @@ class File
         $this->addFileHeader();
         $this->readStream($stream, self::SEND);
         $this->addFileFooter();
-    }
-
-    /**
-     * Send CDR record for specified file.
-     *
-     * @return string
-     */
-    public function getCdrFile(): string
-    {
-        $name = static::filterFilename($this->name);
-
-        // get attributes
-        $comment = $this->opt->getComment();
-
-        // get dos timestamp
-        $time = static::dosTime($this->opt->getTime()->getTimestamp());
-
-        $footer = $this->buildZip64ExtraBlock();
-
-        $fields = [
-            ['V', ZipStream::CDR_FILE_SIGNATURE],   // Central file header signature
-            ['v', ZipStream::ZIP_VERSION_MADE_BY],  // Made by version
-            ['v', $this->version->getValue()],      // Extract by version
-            ['v', $this->bits],                     // General purpose bit flags - data descriptor flag set
-            ['v', $this->method->getValue()],       // Compression method
-            ['V', $time],                           // Timestamp (DOS Format)
-            ['V', $this->crc],                      // CRC32
-            ['V', $this->zlen->getLowFF()],         // Compressed Data Length
-            ['V', $this->len->getLowFF()],          // Original Data Length
-            ['v', strlen($name)],                   // Length of filename
-            ['v', strlen($footer)],                 // Extra data len (see above)
-            ['v', strlen($comment)],                // Length of comment
-            ['v', 0],                               // Disk number
-            ['v', 0],                               // Internal File Attributes
-            ['V', 32],                              // External File Attributes
-            ['V', $this->ofs->getLowFF()]           // Relative offset of local header
-        ];
-
-        // pack fields, then append name and comment
-        $header = ZipStream::packFields($fields);
-
-        return $header . $name . $footer . $comment;
-    }
-
-    /**
-     * @return Bigint
-     */
-    public function getTotalLength(): Bigint
-    {
-        return $this->totalLength;
     }
 }

--- a/src/Option/Archive.php
+++ b/src/Option/Archive.php
@@ -7,11 +7,13 @@ use Psr\Http\Message\StreamInterface;
 
 final class Archive
 {
-    const DEFAULT_DEFLATE_LEVEL = 6;
+    public const DEFAULT_DEFLATE_LEVEL = 6;
+
     /**
      * @var string
      */
     private $comment = '';
+
     /**
      * Size, in bytes, of the largest file to try
      * and load into memory (used by
@@ -22,6 +24,7 @@ final class Archive
      * @var int
      */
     private $largeFileSize = 20 * 1024 * 1024;
+
     /**
      * How to handle large files.  Legal values are
      * Method::STORE() (the default), or
@@ -34,6 +37,7 @@ final class Archive
      * @var Method
      */
     private $largeFileMethod;
+
     /**
      * Boolean indicating whether or not to send
      * the HTTP headers for this file.
@@ -41,12 +45,14 @@ final class Archive
      * @var bool
      */
     private $sendHttpHeaders = false;
+
     /**
      * The method called to send headers
      *
      * @var Callable
      */
     private $httpHeaderCallback = 'header';
+
     /**
      * Enable Zip64 extension, supporting very large
      * archives (any size > 4 GB or file count > 64k)
@@ -54,6 +60,7 @@ final class Archive
      * @var bool
      */
     private $enableZip64 = true;
+
     /**
      * Enable streaming files with single read where
      * general purpose bit 3 indicates local file header
@@ -64,6 +71,7 @@ final class Archive
      * @var bool
      */
     private $zeroHeader = false;
+
     /**
      * Enable reading file stat for determining file size.
      * When a 32-bit system reads file size that is
@@ -77,11 +85,13 @@ final class Archive
      * @var bool
      */
     private $statFiles = true;
+
     /**
      * Enable flush after every write to output stream.
      * @var bool
      */
     private $flushOutput = false;
+
     /**
      * HTTP Content-Disposition.  Defaults to
      * 'attachment', where
@@ -93,6 +103,7 @@ final class Archive
      * @var string
      */
     private $contentDisposition = 'attachment';
+
     /**
      * Note that this does nothing if you are
      * not sending HTTP headers.
@@ -100,6 +111,7 @@ final class Archive
      * @var string
      */
     private $contentType = 'application/x-zip';
+
     /**
      * @var int
      */
@@ -159,12 +171,12 @@ final class Archive
         $this->sendHttpHeaders = $sendHttpHeaders;
     }
 
-    public function getHttpHeaderCallback(): Callable
+    public function getHttpHeaderCallback(): callable
     {
         return $this->httpHeaderCallback;
     }
 
-    public function setHttpHeaderCallback(Callable $httpHeaderCallback): void
+    public function setHttpHeaderCallback(callable $httpHeaderCallback): void
     {
         $this->httpHeaderCallback = $httpHeaderCallback;
     }

--- a/src/Option/File.php
+++ b/src/Option/File.php
@@ -12,18 +12,22 @@ final class File
      * @var string
      */
     private $comment = '';
+
     /**
      * @var Method
      */
     private $method;
+
     /**
      * @var int
      */
     private $deflateLevel;
+
     /**
      * @var DateTimeInterface
      */
     private $time;
+
     /**
      * @var int
      */

--- a/src/Option/Method.php
+++ b/src/Option/Method.php
@@ -14,6 +14,7 @@ use MyCLabs\Enum\Enum;
  */
 class Method extends Enum
 {
-    const STORE = 0x00;
-    const DEFLATE = 0x08;
+    public const STORE = 0x00;
+
+    public const DEFLATE = 0x08;
 }

--- a/src/Option/Version.php
+++ b/src/Option/Version.php
@@ -16,7 +16,9 @@ use MyCLabs\Enum\Enum;
  */
 class Version extends Enum
 {
-    const STORE = 0x000A; // 1.00
-    const DEFLATE = 0x0014; // 2.00
-    const ZIP64 = 0x002D; // 4.50
+    public const STORE = 0x000A; // 1.00
+
+    public const DEFLATE = 0x0014; // 2.00
+
+    public const ZIP64 = 0x002D; // 4.50
 }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace ZipStream;
 
+use function mb_strlen;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
@@ -20,6 +21,29 @@ class Stream implements StreamInterface
     public function __construct($stream)
     {
         $this->stream = $stream;
+    }
+
+    /**
+     * Reads all data from the stream into a string, from the beginning to end.
+     *
+     * This method MUST attempt to seek to the beginning of the stream before
+     * reading data and read the stream until the end is reached.
+     *
+     * Warning: This could attempt to load a large amount of data into memory.
+     *
+     * This method MUST NOT raise an exception in order to conform with PHP's
+     * string casting operations.
+     *
+     * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
+     * @return string
+     */
+    public function __toString(): string
+    {
+        try {
+            $this->seek(0);
+        } catch (RuntimeException $e) {
+        }
+        return (string) stream_get_contents($this->stream);
     }
 
     /**
@@ -47,28 +71,6 @@ class Stream implements StreamInterface
         $result = $this->stream;
         $this->stream = null;
         return $result;
-    }
-
-    /**
-     * Reads all data from the stream into a string, from the beginning to end.
-     *
-     * This method MUST attempt to seek to the beginning of the stream before
-     * reading data and read the stream until the end is reached.
-     *
-     * Warning: This could attempt to load a large amount of data into memory.
-     *
-     * This method MUST NOT raise an exception in order to conform with PHP's
-     * string casting operations.
-     *
-     * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
-     * @return string
-     */
-    public function __toString(): string
-    {
-        try {
-            $this->seek(0);
-        } catch (RuntimeException $e) {}
-        return (string) stream_get_contents($this->stream);
     }
 
     /**
@@ -187,7 +189,7 @@ class Stream implements StreamInterface
         if (fwrite($this->stream, $string) === false) {
             throw new RuntimeException;
         }
-        return \mb_strlen($string);
+        return mb_strlen($string);
     }
 
     /**
@@ -212,7 +214,7 @@ class Stream implements StreamInterface
      *     call returns fewer bytes.
      * @return string Returns the data read from the stream, or an empty string
      *     if no bytes are available.
-     * @throws \RuntimeException if an error occurs.
+     * @throws RuntimeException if an error occurs.
      */
     public function read($length): string
     {
@@ -244,7 +246,7 @@ class Stream implements StreamInterface
      * Returns the remaining contents in a string
      *
      * @return string
-     * @throws \RuntimeException if unable to read or an error occurs while
+     * @throws RuntimeException if unable to read or an error occurs while
      *     reading.
      */
     public function getContents(): string

--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -80,19 +80,24 @@ class ZipStream
      * to prevent file permissions issues upon extract (see #84)
      * 0x603 is 00000110 00000011 in binary, so 6 and 3
      */
-    const ZIP_VERSION_MADE_BY = 0x603;
+    public const ZIP_VERSION_MADE_BY = 0x603;
 
     /**
-     * The following signatures end with 0x4b50, which in ASCII is PK,
+     * The following signatures end with 0x4b50, which in ASCII is PK,
      * the initials of the inventor Phil Katz.
      * See https://en.wikipedia.org/wiki/Zip_(file_format)#File_headers
      */
-    const FILE_HEADER_SIGNATURE = 0x04034b50;
-    const CDR_FILE_SIGNATURE = 0x02014b50;
-    const CDR_EOF_SIGNATURE = 0x06054b50;
-    const DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
-    const ZIP64_CDR_EOF_SIGNATURE = 0x06064b50;
-    const ZIP64_CDR_LOCATOR_SIGNATURE = 0x07064b50;
+    public const FILE_HEADER_SIGNATURE = 0x04034b50;
+
+    public const CDR_FILE_SIGNATURE = 0x02014b50;
+
+    public const CDR_EOF_SIGNATURE = 0x06054b50;
+
+    public const DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
+
+    public const ZIP64_CDR_EOF_SIGNATURE = 0x06064b50;
+
+    public const ZIP64_CDR_LOCATOR_SIGNATURE = 0x07064b50;
 
     /**
      * Global Options
@@ -376,34 +381,6 @@ class ZipStream
     }
 
     /**
-     * Send ZIP64 CDR EOF (Central Directory Record End-of-File) record.
-     *
-     * @return void
-     */
-    protected function addCdr64Eof(): void
-    {
-        $num_files = count($this->files);
-        $cdr_length = $this->cdr_ofs;
-        $cdr_offset = $this->ofs;
-
-        $fields = [
-            ['V', static::ZIP64_CDR_EOF_SIGNATURE],     // ZIP64 end of central file header signature
-            ['P', 44],                                  // Length of data below this header (length of block - 12) = 44
-            ['v', static::ZIP_VERSION_MADE_BY],         // Made by version
-            ['v', Version::ZIP64],                      // Extract by version
-            ['V', 0x00],                                // disk number
-            ['V', 0x00],                                // no of disks
-            ['P', $num_files],                          // no of entries on disk
-            ['P', $num_files],                          // no of entries in cdr
-            ['P', $cdr_length],                         // CDR size
-            ['P', $cdr_offset],                         // CDR offset
-        ];
-
-        $ret = static::packFields($fields);
-        $this->send($ret);
-    }
-
-    /**
      * Create a format string and argument list for pack(), then call
      * pack() and return the result.
      *
@@ -477,6 +454,62 @@ class ZipStream
     }
 
     /**
+     * Is this file larger than large_file_size?
+     *
+     * @param string $path
+     * @return bool
+     */
+    public function isLargeFile(string $path): bool
+    {
+        if (!$this->opt->isStatFiles()) {
+            return false;
+        }
+        $stat = stat($path);
+        return $stat['size'] > $this->opt->getLargeFileSize();
+    }
+
+    /**
+     * Save file attributes for trailing CDR record.
+     *
+     * @param File $file
+     * @return void
+     */
+    public function addToCdr(File $file): void
+    {
+        $file->ofs = $this->ofs;
+        $this->ofs = $this->ofs->add($file->getTotalLength());
+        $this->files[] = $file->getCdrFile();
+    }
+
+    /**
+     * Send ZIP64 CDR EOF (Central Directory Record End-of-File) record.
+     *
+     * @return void
+     */
+    protected function addCdr64Eof(): void
+    {
+        $num_files = count($this->files);
+        $cdr_length = $this->cdr_ofs;
+        $cdr_offset = $this->ofs;
+
+        $fields = [
+            ['V', static::ZIP64_CDR_EOF_SIGNATURE],     // ZIP64 end of central file header signature
+            ['P', 44],                                  // Length of data below this header (length of block - 12) = 44
+            ['v', static::ZIP_VERSION_MADE_BY],         // Made by version
+            ['v', Version::ZIP64],                      // Extract by version
+            ['V', 0x00],                                // disk number
+            ['V', 0x00],                                // no of disks
+            ['P', $num_files],                          // no of entries on disk
+            ['P', $num_files],                          // no of entries in cdr
+            ['P', $cdr_length],                         // CDR size
+            ['P', $cdr_offset],                         // CDR offset
+        ];
+
+        $ret = static::packFields($fields);
+        $this->send($ret);
+    }
+
+    /**
      * Send HTTP headers for this stream.
      *
      * @return void
@@ -495,13 +528,13 @@ class ZipStream
             $disposition .= "; filename*=UTF-8''{$urlencoded}";
         }
 
-        $headers = array(
+        $headers = [
             'Content-Type' => $this->opt->getContentType(),
             'Content-Disposition' => $disposition,
             'Pragma' => 'public',
             'Cache-Control' => 'public, must-revalidate',
-            'Content-Transfer-Encoding' => 'binary'
-        );
+            'Content-Transfer-Encoding' => 'binary',
+        ];
 
         $call = $this->opt->getHttpHeaderCallback();
         foreach ($headers as $key => $val) {
@@ -570,33 +603,5 @@ class ZipStream
         $this->ofs = new Bigint();
         $this->cdr_ofs = new Bigint();
         $this->opt = new ArchiveOptions();
-    }
-
-    /**
-     * Is this file larger than large_file_size?
-     *
-     * @param string $path
-     * @return bool
-     */
-    public function isLargeFile(string $path): bool
-    {
-        if (!$this->opt->isStatFiles()) {
-            return false;
-        }
-        $stat = stat($path);
-        return $stat['size'] > $this->opt->getLargeFileSize();
-    }
-
-    /**
-     * Save file attributes for trailing CDR record.
-     *
-     * @param File $file
-     * @return void
-     */
-    public function addToCdr(File $file): void
-    {
-        $file->ofs = $this->ofs;
-        $this->ofs = $this->ofs->add($file->getTotalLength());
-        $this->files[] = $file->getCdrFile();
     }
 }

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -3,9 +3,13 @@ declare(strict_types=1);
 
 namespace ZipStreamTest;
 
-use org\bovigo\vfs\vfsStream;
 use GuzzleHttp\Psr7\Response;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use ZipArchive;
 use ZipStream\File;
 use ZipStream\Option\Archive as ArchiveOptions;
 use ZipStream\Option\File as FileOptions;
@@ -18,7 +22,7 @@ use ZipStream\ZipStream;
  */
 class ZipStreamTest extends TestCase
 {
-    const OSX_ARCHIVE_UTILITY =
+    public const OSX_ARCHIVE_UTILITY =
         '/System/Library/CoreServices/Applications/Archive Utility.app/Contents/MacOS/Archive Utility';
 
     public function testFileNotFoundException(): void
@@ -45,7 +49,7 @@ class ZipStreamTest extends TestCase
     public function testDostime(): void
     {
         // Allows testing of protected method
-        $class = new \ReflectionClass(File::class);
+        $class = new ReflectionClass(File::class);
         $method = $class->getMethod('dostime');
         $method->setAccessible(true);
 
@@ -82,75 +86,6 @@ class ZipStreamTest extends TestCase
         $this->assertStringEqualsFile($tmpDir . '/test/sample.txt', 'More Simple Sample Data');
     }
 
-    /**
-     * @return array
-     */
-    protected function getTmpFileStream(): array
-    {
-        $tmp = tempnam(sys_get_temp_dir(), 'zipstreamtest');
-        $stream = fopen($tmp, 'wb+');
-
-        return array($tmp, $stream);
-    }
-
-    /**
-     * @param string $tmp
-     * @return string
-     */
-    protected function validateAndExtractZip($tmp): string
-    {
-        $tmpDir = $this->getTmpDir();
-
-        $zipArch = new \ZipArchive;
-        $res = $zipArch->open($tmp);
-
-        if ($res !== true) {
-            $this->fail("Failed to open {$tmp}. Code: $res");
-
-            return $tmpDir;
-        }
-
-        $this->assertSame(0, $zipArch->status);
-        $this->assertSame(0, $zipArch->statusSys);
-
-        $zipArch->extractTo($tmpDir);
-        $zipArch->close();
-
-        return $tmpDir;
-    }
-
-    protected function getTmpDir(): string
-    {
-        $tmp = tempnam(sys_get_temp_dir(), 'zipstreamtest');
-        unlink($tmp);
-        mkdir($tmp) or $this->fail('Failed to make directory');
-
-        return $tmp;
-    }
-
-    /**
-     * @param string $path
-     * @return string[]
-     */
-    protected function getRecursiveFileList(string $path): array
-    {
-        $data = array();
-        $path = (string)realpath($path);
-        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path));
-
-        $pathLen = strlen($path);
-        foreach ($files as $file) {
-            $filePath = $file->getRealPath();
-            if (!is_dir($filePath)) {
-                $data[] = substr($filePath, $pathLen + 1);
-            }
-        }
-
-        sort($data);
-
-        return $data;
-    }
-
     public function testAddFileUtf8NameComment(): void
     {
         [$tmp, $stream] = $this->getTmpFileStream();
@@ -177,10 +112,10 @@ class ZipStreamTest extends TestCase
         $tmpDir = $this->validateAndExtractZip($tmp);
 
         $files = $this->getRecursiveFileList($tmpDir);
-        $this->assertSame(array($name), $files);
+        $this->assertSame([$name], $files);
         $this->assertStringEqualsFile($tmpDir . '/' . $name, $content);
 
-        $zipArch = new \ZipArchive();
+        $zipArch = new ZipArchive();
         $zipArch->open($tmp);
         $this->assertSame($comment, $zipArch->getCommentName($name));
     }
@@ -244,7 +179,7 @@ class ZipStreamTest extends TestCase
         $zip->finish();
         fclose($stream);
 
-        $zipArch = new \ZipArchive();
+        $zipArch = new ZipArchive();
         $zipArch->open($tmp);
 
         $sample1 = $zipArch->statName('sample.txt');
@@ -308,7 +243,7 @@ class ZipStreamTest extends TestCase
         $tmpDir = $this->validateAndExtractZip($tmp);
 
         $files = $this->getRecursiveFileList($tmpDir);
-        $this->assertSame(array('sample.txt', 'test' . DIRECTORY_SEPARATOR . 'sample.txt'), $files);
+        $this->assertSame(['sample.txt', 'test' . DIRECTORY_SEPARATOR . 'sample.txt'], $files);
 
         $this->assertStringEqualsFile($tmpDir . '/sample.txt', 'Sample String Data');
         $this->assertStringEqualsFile($tmpDir . '/test/sample.txt', 'More Simple Sample Data');
@@ -339,7 +274,7 @@ class ZipStreamTest extends TestCase
         $zip->finish();
         fclose($stream);
 
-        $zipArch = new \ZipArchive();
+        $zipArch = new ZipArchive();
         $zipArch->open($tmp);
 
         $sample1 = $zipArch->statName('sample.txt');
@@ -365,42 +300,6 @@ class ZipStreamTest extends TestCase
                 }
             }
         }
-    }
-
-    protected function addLargeFileFileFromPath($method, $zeroHeader, $zip64): void
-    {
-        [$tmp, $stream] = $this->getTmpFileStream();
-
-        $options = new ArchiveOptions();
-        $options->setOutputStream($stream);
-        $options->setLargeFileMethod($method);
-        $options->setLargeFileSize(5);
-        $options->setZeroHeader($zeroHeader);
-        $options->setEnableZip64($zip64);
-
-        $zip = new ZipStream(null, $options);
-
-        [$tmpExample, $streamExample] = $this->getTmpFileStream();
-        for ($i = 0; $i <= 10000; $i++) {
-            fwrite($streamExample, sha1((string)$i));
-            if ($i % 100 === 0) {
-                fwrite($streamExample, "\n");
-            }
-        }
-        fclose($streamExample);
-        $shaExample = sha1_file($tmpExample);
-        $zip->addFileFromPath('sample.txt', $tmpExample);
-        unlink($tmpExample);
-
-        $zip->finish();
-        fclose($stream);
-
-        $tmpDir = $this->validateAndExtractZip($tmp);
-
-        $files = $this->getRecursiveFileList($tmpDir);
-        $this->assertSame(array('sample.txt'), $files);
-
-        $this->assertSame(sha1_file($tmpDir . '/sample.txt'), $shaExample, "SHA-1 Mismatch Method: {$method}");
     }
 
     public function testAddFileFromStream(): void
@@ -434,7 +333,7 @@ class ZipStreamTest extends TestCase
         $tmpDir = $this->validateAndExtractZip($tmp);
 
         $files = $this->getRecursiveFileList($tmpDir);
-        $this->assertSame(array('sample.txt', 'test' . DIRECTORY_SEPARATOR . 'sample.txt'), $files);
+        $this->assertSame(['sample.txt', 'test' . DIRECTORY_SEPARATOR . 'sample.txt'], $files);
 
         $this->assertStringEqualsFile(__FILE__, file_get_contents($tmpDir . '/sample.txt'));
         $this->assertStringEqualsFile($tmpDir . '/test/sample.txt', 'More Simple Sample Data');
@@ -467,7 +366,7 @@ class ZipStreamTest extends TestCase
         $zip->finish();
         fclose($stream);
 
-        $zipArch = new \ZipArchive();
+        $zipArch = new ZipArchive();
         $zipArch->open($tmp);
 
         $sample1 = $zipArch->statName('sample.txt');
@@ -501,7 +400,7 @@ class ZipStreamTest extends TestCase
         $tmpDir = $this->validateAndExtractZip($tmp);
 
         $files = $this->getRecursiveFileList($tmpDir);
-        $this->assertSame(array('sample.json'), $files);
+        $this->assertSame(['sample.json'], $files);
         $this->assertStringEqualsFile($tmpDir . '/sample.json', $body);
     }
 
@@ -528,7 +427,7 @@ class ZipStreamTest extends TestCase
         $tmpDir = $this->validateAndExtractZip($tmp);
         $files = $this->getRecursiveFileList($tmpDir);
 
-        $this->assertSame(array('sample.json'), $files);
+        $this->assertSame(['sample.json'], $files);
         $this->assertStringEqualsFile($tmpDir . '/sample.json', $body);
     }
 
@@ -557,7 +456,7 @@ class ZipStreamTest extends TestCase
         $tmpDir = $this->validateAndExtractZip($tmp);
 
         $files = $this->getRecursiveFileList($tmpDir);
-        $this->assertSame(array('sample.json'), $files);
+        $this->assertSame(['sample.json'], $files);
         $this->assertStringEqualsFile($tmpDir . '/sample.json', $body);
     }
 
@@ -610,5 +509,110 @@ class ZipStreamTest extends TestCase
 
         // WORKAROUND (2/2): add back output buffering so that PHPUnit doesn't complain that it is missing
         ob_start();
+    }
+
+    /**
+     * @return array
+     */
+    protected function getTmpFileStream(): array
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'zipstreamtest');
+        $stream = fopen($tmp, 'wb+');
+
+        return [$tmp, $stream];
+    }
+
+    /**
+     * @param string $tmp
+     * @return string
+     */
+    protected function validateAndExtractZip($tmp): string
+    {
+        $tmpDir = $this->getTmpDir();
+
+        $zipArch = new ZipArchive;
+        $res = $zipArch->open($tmp);
+
+        if ($res !== true) {
+            $this->fail("Failed to open {$tmp}. Code: $res");
+
+            return $tmpDir;
+        }
+
+        $this->assertSame(0, $zipArch->status);
+        $this->assertSame(0, $zipArch->statusSys);
+
+        $zipArch->extractTo($tmpDir);
+        $zipArch->close();
+
+        return $tmpDir;
+    }
+
+    protected function getTmpDir(): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'zipstreamtest');
+        unlink($tmp);
+        mkdir($tmp) or $this->fail('Failed to make directory');
+
+        return $tmp;
+    }
+
+    /**
+     * @param string $path
+     * @return string[]
+     */
+    protected function getRecursiveFileList(string $path): array
+    {
+        $data = [];
+        $path = (string)realpath($path);
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
+
+        $pathLen = strlen($path);
+        foreach ($files as $file) {
+            $filePath = $file->getRealPath();
+            if (!is_dir($filePath)) {
+                $data[] = substr($filePath, $pathLen + 1);
+            }
+        }
+
+        sort($data);
+
+        return $data;
+    }
+
+    protected function addLargeFileFileFromPath($method, $zeroHeader, $zip64): void
+    {
+        [$tmp, $stream] = $this->getTmpFileStream();
+
+        $options = new ArchiveOptions();
+        $options->setOutputStream($stream);
+        $options->setLargeFileMethod($method);
+        $options->setLargeFileSize(5);
+        $options->setZeroHeader($zeroHeader);
+        $options->setEnableZip64($zip64);
+
+        $zip = new ZipStream(null, $options);
+
+        [$tmpExample, $streamExample] = $this->getTmpFileStream();
+        for ($i = 0; $i <= 10000; $i++) {
+            fwrite($streamExample, sha1((string)$i));
+            if ($i % 100 === 0) {
+                fwrite($streamExample, "\n");
+            }
+        }
+        fclose($streamExample);
+        $shaExample = sha1_file($tmpExample);
+        $zip->addFileFromPath('sample.txt', $tmpExample);
+        unlink($tmpExample);
+
+        $zip->finish();
+        fclose($stream);
+
+        $tmpDir = $this->validateAndExtractZip($tmp);
+
+        $files = $this->getRecursiveFileList($tmpDir);
+        $this->assertSame(['sample.txt'], $files);
+
+        $this->assertSame(sha1_file($tmpDir . '/sample.txt'), $shaExample, "SHA-1 Mismatch Method: {$method}");
     }
 }

--- a/test/bug/BugHonorFileTimeTest.php
+++ b/test/bug/BugHonorFileTimeTest.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 namespace BugHonorFileTimeTest;
 
 use DateTime;
-use PHPUnit\Framework\TestCase;
-use ZipStream\Option\{
-    Archive,
-    File
-};
-use ZipStream\ZipStream;
-
 use function fopen;
+use PHPUnit\Framework\TestCase;
+use ZipStream\Option\Archive;
+use ZipStream\Option\File;
+
+use ZipStream\ZipStream;
 
 /**
  * Asserts that specified last-modified timestamps are not overwritten when a


### PR DESCRIPTION
* add a config to automatically lint and fix php code for syntax and
  some rules
* add `composer test`, `composer lint` and `composer dry-lint` commands

I think all changes here are reasonable, nothing crazy. And making it
automatic is a great improvement.

See
https://github.com/maennchen/ZipStream-PHP/pull/218#issuecomment-1194914831

Superseeds #218

Next step will be to add it to the github actions workflow.