### PR TITLE
Updated Symfony code example

### DIFF
--- a/guides/Symfony.rst
+++ b/guides/Symfony.rst
@@ -47,9 +47,9 @@ stored in an AWS S3 bucket by key:
             // this is needed to prevent issues with truncated zip files
             //initialise zipstream with output zip filename and options.
             $zip = new ZipStream\ZipStream(
-                'outputName' => 'test.zip',
-                'defaultEnableZeroHeader' => true,
-                'contentType' => 'application/octet-stream',
+                outputName: 'test.zip',
+                defaultEnableZeroHeader: true,
+                contentType: 'application/octet-stream',
             );
 
             //loop keys - useful for multiple files


### PR DESCRIPTION
Example was using wrong notation, looks like an array notation without the corresponding array 'wrapper' (`array()` / `[]`). Updated to named arguments.