### PR TITLE
Maximum buffer size

### DIFF
--- a/src/Option/Archive.php
+++ b/src/Option/Archive.php
@@ -94,10 +94,12 @@ final class Archive
     private $flushOutput = false;
 
     /**
-     * When set output will be flushed everytime it hits specified amount of bytes
+     * When set, output stream will be flushed everytime it hits specified amount of bytes.
+     * Defaulted to 0 which translate to unlimited buffer size.
+     * $outputStreamBufferSize does not require $flushOutput to be true.
      * @var int
      */
-    private $maxOutputSize = 0;
+    private $outputStreamBufferSize = 0;
 
     /**
      * HTTP Content-Disposition.  Defaults to
@@ -207,28 +209,29 @@ final class Archive
     {
         $this->zeroHeader = $zeroHeader;
     }
-
+    
     public function isFlushOutput(): bool
     {
         return $this->flushOutput;
     }
 
+    
     public function setFlushOutput(bool $flushOutput): void
     {
         $this->flushOutput = $flushOutput;
     }
 
-    public function getMaxOutputSize(): int
+    public function getOutputStreamBufferSize(): int
     {
-        return $this->maxOutputSize;
+        return $this->outputStreamBufferSize;
     }
 
     /**
      * @param int $size
      */
-    public function setMaxOutputSize(int $size): void
+    public function setOutputStreamBufferSize(int $size): void
     {
-        $this->maxOutputSize = $size;
+        $this->outputStreamBufferSize = $size;
     }
 
     public function isStatFiles(): bool

--- a/src/Option/Archive.php
+++ b/src/Option/Archive.php
@@ -94,6 +94,12 @@ final class Archive
     private $flushOutput = false;
 
     /**
+     * When set output will be flushed everytime it hits specified amount of bytes
+     * @var int
+     */
+    private $maxOutputSize = 0;
+
+    /**
      * HTTP Content-Disposition.  Defaults to
      * 'attachment', where
      * FILENAME is the specified filename.
@@ -210,6 +216,19 @@ final class Archive
     public function setFlushOutput(bool $flushOutput): void
     {
         $this->flushOutput = $flushOutput;
+    }
+
+    public function getMaxOutputSize(): int
+    {
+        return $this->maxOutputSize;
+    }
+
+    /**
+     * @param int $size
+     */
+    public function setMaxOutputSize(int $size): void
+    {
+        $this->maxOutputSize = $size;
     }
 
     public function isStatFiles(): bool

--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -439,9 +439,9 @@ class ZipStream
         }
         $this->need_headers = false;
 
-        if ($this->opt->getMaxOutputSize()) {
-            while ((strlen($str) + $this->output_size) >= $this->opt->getMaxOutputSize()) {
-                $allowedLength = $this->opt->getMaxOutputSize() - $this->output_size;
+        if ($this->opt->getOutputStreamBufferSize()) {
+            while ((strlen($str) + $this->output_size) >= $this->opt->getOutputStreamBufferSize()) {
+                $allowedLength = $this->opt->getOutputStreamBufferSize() - $this->output_size;
                 $this->write(substr($str, 0, $allowedLength));
                 $str = substr($str, $allowedLength);
                 $this->flushOutput();

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -549,7 +549,7 @@ class ZipStreamTest extends TestCase
 
         $options = new ArchiveOptions();
         $options->setOutputStream($stream);
-        $options->setMaxOutputSize(3);
+        $options->setOutputStreamBufferSize(3);
 
         $zip = new ZipStream(null, $options);
 

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -543,6 +543,31 @@ class ZipStreamTest extends TestCase
         ob_start();
     }
 
+    public function testCreateArchiveWithMaxOutputSize(): void
+    {
+        [$tmp, $stream] = $this->getTmpFileStream();
+
+        $options = new ArchiveOptions();
+        $options->setOutputStream($stream);
+        $options->setMaxOutputSize(3);
+
+        $zip = new ZipStream(null, $options);
+
+        $zip->addFile('sample.txt', 'Sample String Data');
+        $zip->addFile('test/sample.txt', 'More Simple Sample Data');
+
+        $zip->finish();
+        fclose($stream);
+
+        $tmpDir = $this->validateAndExtractZip($tmp);
+
+        $files = $this->getRecursiveFileList($tmpDir);
+        $this->assertSame(['sample.txt', 'test' . DIRECTORY_SEPARATOR . 'sample.txt'], $files);
+
+        $this->assertStringEqualsFile($tmpDir . '/sample.txt', 'Sample String Data');
+        $this->assertStringEqualsFile($tmpDir . '/test/sample.txt', 'More Simple Sample Data');
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
When streaming the output to an external service like amazon s3 with very large files, we wanted more control over the flushed size. isFlushedOutput allowed us to flush only at the end of the transfer or for every send operation. We wanted to chunk at specific size to take advantage of S3's multipart upload.
We introduce a new property $outputStreamBufferSize which sets an upper limit of data stored in the buffer. When the limit is reached, a flush is triggered.