### PR TITLE
Fixes #235 Remove `PHP_CS_FIXER_IGNORE_ENV`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "ext-zip": "*",
     "mikey179/vfsstream": "^1.6",
     "php-coveralls/php-coveralls": "^2.5",
-    "friendsofphp/php-cs-fixer": "^3.13",
+    "friendsofphp/php-cs-fixer": "^3.16",
     "vimeo/psalm": "^5.0"
   },
   "suggest": {
@@ -40,7 +40,7 @@
     "guzzlehttp/psr7": "^2.4"
   },
   "scripts": {
-    "format": "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix",
+    "format": "php-cs-fixer fix",
     "test": "composer run test:unit && composer run test:formatted && composer run test:lint",
     "test:unit": "phpunit --coverage-clover=coverage.clover.xml --coverage-html cov",
     "test:unit:slow": "composer run test:unit -- --group slow",


### PR DESCRIPTION
I saw the issue about `PHP_CS_FIXER_IGNORE_ENV` and realised that PHP 8.2 was now officially supported :
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer#supported-php-versions

So here is a small PR.

Fixes #235 