### PR TITLE
chore(deps): allow psr/http-message v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": "^8.0",
     "ext-mbstring": "*",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.0 || ^2.0",
     "myclabs/php-enum": "^1.5"
   },
   "require-dev": {


### PR DESCRIPTION
<!---
name: ⚙ Improvement
about: You have some improvement to make ZipStream-PHP better?
labels: enhancement
--->

Since upgrading to v3 is not possible for some libs right now, this allows to user psr/http-message v2 with v2 of zipstream.
