### PR TITLE
Only enable Zip64 if it is required to maximize compatibility

### DIFF
--- a/test/Assertions.php
+++ b/test/Assertions.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZipStream\Test;
+
+trait Assertions
+{
+    protected function assertFileContains(string $filePath, string $needle): void
+    {
+        $last = '';
+
+        $handle = fopen($filePath, 'r');
+        while (!feof($handle)) {
+            $line = fgets($handle, 1024);
+
+            if(str_contains($last . $line, $needle)) {
+                fclose($handle);
+                return;
+            }
+
+            $last = $line;
+        }
+
+        fclose($handle);
+
+        $this->fail("File {$filePath} must contain {$needle}");
+    }
+
+    protected function assertFileDoesNotContain(string $filePath, string $needle): void
+    {
+        $last = '';
+
+        $handle = fopen($filePath, 'r');
+        while (!feof($handle)) {
+            $line = fgets($handle, 1024);
+
+            if(str_contains($last . $line, $needle)) {
+                fclose($handle);
+
+                $this->fail("File {$filePath} must not contain {$needle}");
+            }
+
+            $last = $line;
+        }
+
+        fclose($handle);
+    }
+}


### PR DESCRIPTION
Zip64 was enabled even if it is not required for a file.

Should improve situation of #267