### PR TITLE
Strip additional files from distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,15 @@
 *.yml      text eol=lf
 *.xml      text eol=lf
 
-/.github          export-ignore
-/.gitattributes   export-ignore
-/.gitignore       export-ignore
+/.editorconfig            export-ignore
+/.gitattributes           export-ignore
+/.github                  export-ignore
+/.gitignore               export-ignore
+/.phive                   export-ignore
+/.php-cs-fixer.dist.php   export-ignore
+/.phpdoc                  export-ignore
+/.tool-versions           export-ignore
+/phpdoc.dist.xml          export-ignore
+/phpunit.xml.dist         export-ignore
+/psalm.xml                export-ignore
+/test                     export-ignore


### PR DESCRIPTION
This strips additional files from the distribution to reduce the traffic / download times and to make /vendor/ easier to review.

The `.tar` export of `git archive` is roughly 90kB smaller, from 220kB down to 130kB, mostly due to no longer including /test/.