### PR TITLE
Fix Strict Simulation for empty files

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -107,11 +107,11 @@ class File
 
         $this->addFileHeader();
 
-        $detectedSize = $forecastSize ?? $this->compressedSize;
+        $detectedSize = $forecastSize ?? ($this->compressedSize > 0 ? $this->compressedSize : null);
 
         if (
             $this->isSimulation() &&
-            $detectedSize > 0
+            $detectedSize !== null
         ) {
             ($this->recordSentBytes)($detectedSize);
         } else {

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -1104,7 +1104,8 @@ class ZipStreamTest extends TestCase
     public function testExecuteSimulation(): void
     {
         $zip = new ZipStream(
-            operationMode: OperationMode::SIMULATE_LAX,
+            operationMode: OperationMode::SIMULATE_STRICT,
+            defaultCompressionMethod: CompressionMethod::STORE,
             defaultEnableZeroHeader: false,
             sendHttpHeaders: false,
             outputStream: $this->tempfileStream,
@@ -1115,6 +1116,14 @@ class ZipStreamTest extends TestCase
             exactSize: 18,
             callback: function () {
                 return 'Sample String Data';
+            }
+        );
+
+        $zip->addFileFromCallback(
+            '.gitkeep',
+            exactSize: 0,
+            callback: function () {
+                return '';
             }
         );
 
@@ -1131,7 +1140,7 @@ class ZipStreamTest extends TestCase
         $tmpDir = $this->validateAndExtractZip($this->tempfile);
 
         $files = $this->getRecursiveFileList($tmpDir);
-        $this->assertSame(['sample.txt'], $files);
+        $this->assertSame(['.gitkeep', 'sample.txt'], $files);
     }
 
     public function testExecuteSimulationBeforeFinish(): void


### PR DESCRIPTION
<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

<!--
- Please do not send a pull request for an issue in a version of ZipStream-PHP
  that is no longer supported.
  See: https://github.com/maennchen/ZipStream-PHP#version-support
- Please target the oldest branch of ZipStream-PHP that is still supported and
  affected by this bug.
-->

Fixes #301 
