### PR TITLE
Fix date to DOS time conversion

### DIFF
--- a/src/Time.php
+++ b/src/Time.php
@@ -26,20 +26,14 @@ abstract class Time
 
         $dateTime = DateTimeImmutable::createFromInterface($dateTime)->sub(new DateInterval('P1980Y'));
 
-        ['year' => $year,
-            'mon' => $month,
-            'mday' => $day,
-            'hours' => $hour,
-            'minutes' => $minute,
-            'seconds' => $second
-        ] = getdate($dateTime->getTimestamp());
+        [$year, $month, $day, $hour, $minute, $second] = explode(' ', $dateTime->format('Y n j G i s'));
 
         return
-            ($year << 25) |
-            ($month << 21) |
-            ($day << 16) |
-            ($hour << 11) |
-            ($minute << 5) |
-            ($second >> 1);
+            ((int) $year << 25) |
+            ((int) $month << 21) |
+            ((int) $day << 16) |
+            ((int) $hour << 11) |
+            ((int) $minute << 5) |
+            ((int) $second >> 1);
     }
 }

--- a/test/TimeTest.php
+++ b/test/TimeTest.php
@@ -23,6 +23,15 @@ class TimeTest extends TestCase
             Time::dateTimeToDosTime(new DateTimeImmutable('1980-01-01T00:00:00+00:00')),
             2162688
         );
+
+        // Local timezone different than UTC.
+        $prevLocalTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+        $this->assertSame(
+            Time::dateTimeToDosTime(new DateTimeImmutable('1980-01-01T00:00:00+00:00')),
+            2162688
+        );
+        date_default_timezone_set($prevLocalTimezone);
     }
 
     public function testTooEarlyDateToDosTime(): void


### PR DESCRIPTION
Fixes bug where DOS times are calculated incorrectly when the local machine timezone is different from UTC.