### PR TITLE
Fix PHP 8.4 deprecation in test

### DIFF
--- a/test/FaultInjectionResource.php
+++ b/test/FaultInjectionResource.php
@@ -25,7 +25,7 @@ class FaultInjectionResource
         return fopen(self::NAME . '://foobar', 'rw+', false, self::createStreamContext($injectFaults));
     }
 
-    public function stream_open(string $path, string $mode, int $options, string &$opened_path = null): bool
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path = null): bool
     {
         $options = stream_context_get_options($this->context);
 


### PR DESCRIPTION
* Implicitly nullable parameter types are deprecated in PHP 8.4
  * https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
* `?Type` syntax has been available since PHP 7.1, so there are no backward compatibility issues
  * https://wiki.php.net/rfc/nullable_types