### PR TITLE
Fix Simulation Filesize when using Zip64 & Zero Header

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -113,6 +113,8 @@ class File
             $this->isSimulation() &&
             $detectedSize !== null
         ) {
+            $this->uncompressedSize = $detectedSize;
+            $this->compressedSize = $detectedSize;
             ($this->recordSentBytes)($detectedSize);
         } else {
             $this->readStream(send: true);


### PR DESCRIPTION
<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

<!--
- Please do not send a pull request for an issue in a version of ZipStream-PHP
  that is no longer supported.
  See: https://github.com/maennchen/ZipStream-PHP#version-support
- Please target the oldest branch of ZipStream-PHP that is still supported and
  affected by this bug.
-->

Fixes #329
