### PR TITLE
Add development related files as export-ignore to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,17 @@
-.gitignore     text eol=lf
-.gitattributes text eol=lf
-*.md       text eol=lf
-*.php      text eol=lf
-*.yml      text eol=lf
-*.xml      text eol=lf
+.editorconfig                       export-ignore
+.gitattributes          text eol=lf export-ignore
+.gitignore              text eol=lf export-ignore
+.php-cs-fixer.dist.php              export-ignore
+.tool-versions                      export-ignore
+/.github/                           export-ignore
+/.phive/                            export-ignore
+/.phpdoc/                           export-ignore
+/test/&                             export-ignore
+phpdoc.dist.xml                     export-ignore
+phpunit.xml.dist                    export-ignore
+psalm.xml                           export-ignore
+
+*.md                    text eol=lf
+*.php                   text eol=lf
+*.xml                   text eol=lf
+*.yml                   text eol=lf


### PR DESCRIPTION
Certain files are not required when only using the library as a dependency. So we do not need to add those files to generated archives.

<!---
name: ⚙ Improvement
about: You have some improvement to make ZipStream-PHP better?
labels: enhancement
--->

<!--
- Please target the `main` branch of ZipStream-PHP.
-->
