### PR TITLE
Add CallbackStreamWrapper for custom ZIP output (#199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,38 @@ $zip->addFileFromPath(
 $zip->finish();
 ```
 
+### Callback Output
+
+You can stream ZIP data to a custom callback function instead of directly to the browser:
+
+```php
+use ZipStream\ZipStream;
+use ZipStream\Stream\CallbackStreamWrapper;
+
+// Stream to a callback function with proper file handling
+$outputFile = fopen('output.zip', 'wb');
+$backupFile = fopen('backup.zip', 'wb');
+
+$zip = new ZipStream(
+    outputStream: CallbackStreamWrapper::open(function (string $data) use ($outputFile, $backupFile) {
+        // Handle ZIP data as it's generated
+        fwrite($outputFile, $data);
+        
+        // Send to multiple destinations efficiently
+        echo $data; // Browser
+        fwrite($backupFile, $data); // Backup file
+    }),
+    sendHttpHeaders: false,
+);
+
+$zip->addFile('hello.txt', 'Hello World!');
+$zip->finish();
+
+// Clean up resources
+fclose($outputFile);
+fclose($backupFile);
+```
+
 ## Questions
 
 **💬 Questions? Please Read This First!**

--- a/guides/Options.rst
+++ b/guides/Options.rst
@@ -17,6 +17,9 @@ Here is the full list of options available to you. You can also have a look at
         //
         // Setup with `psr/http-message` & `guzzlehttp/psr7` dependencies
         // required when using `Psr\Http\Message\StreamInterface`.
+        //
+        // Can also use CallbackStreamWrapper for custom output handling:
+        // outputStream: CallbackStreamWrapper::open(function($data) { /* handle data */ }),
         outputStream: $filePointer,
 
         // Set the deflate level (default is 6; use -1 to disable it)

--- a/src/Stream/CallbackStreamWrapper.php
+++ b/src/Stream/CallbackStreamWrapper.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZipStream\Stream;
+
+/**
+ * Stream wrapper that allows writing data to a callback function.
+ * 
+ * This wrapper creates a virtual stream that forwards all written data
+ * to a provided callback function, enabling custom output handling
+ * such as streaming to HTTP responses, files, or other destinations.
+ * 
+ * @psalm-suppress UnusedClass Used dynamically through stream_wrapper_register
+ */
+final class CallbackStreamWrapper
+{
+    public const PROTOCOL = 'zipcb';
+
+    /** @var array<string, callable(string):void> Map of stream IDs to callback functions */
+    private static array $callbacks = [];
+
+    /** @var string|null Unique identifier for this stream instance */
+    private ?string $id = null;
+
+    /** @var int Current position in the stream */
+    private int $pos = 0;
+
+    /**
+     * Create a new callback stream.
+     *
+     * @param callable(string):void $callback Function to call with written data
+     * @return resource|false Stream resource or false on failure
+     */
+    public static function open(callable $callback)
+    {
+        if (!in_array(self::PROTOCOL, stream_get_wrappers(), true)) {
+            if (!stream_wrapper_register(self::PROTOCOL, self::class)) {
+                return false;
+            }
+        }
+
+        // Generate cryptographically secure unique ID to prevent collisions
+        $id = 'cb_' . bin2hex(random_bytes(16));
+        self::$callbacks[$id] = $callback;
+
+        $resource = fopen(self::PROTOCOL . "://{$id}", 'wb');
+        return $resource;
+    }
+
+    /**
+     * Clean up all registered callbacks (useful for testing).
+     *
+     * @internal
+     */
+    public static function cleanup(): void
+    {
+        self::$callbacks = [];
+    }
+
+    /**
+     * Destructor - ensures cleanup even if stream_close() isn't called.
+     * Prevents memory leaks in long-running processes.
+     */
+    public function __destruct()
+    {
+        $this->stream_close();
+    }
+
+    /**
+     * Open the stream.
+     *
+     * @param string $path Stream path containing the callback ID
+     * @param string $mode File mode (must contain 'w' for writing)
+     * @param int $options Stream options (required by interface, unused)
+     * @param string|null $opened_path Opened path reference (required by interface, unused)
+     * @return bool True if stream opened successfully
+     * @psalm-suppress UnusedParam $options and $opened_path are required by the stream wrapper interface
+     */
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
+    {
+        if (!str_contains($mode, 'w')) {
+            return false;
+        }
+
+        $host = parse_url($path, PHP_URL_HOST);
+        if ($host === false || $host === null) {
+            return false;
+        }
+
+        $this->id = $host;
+        return isset(self::$callbacks[$this->id]);
+    }
+
+    /**
+     * Write data to the callback.
+     *
+     * @param string $data Data to write
+     * @return int Number of bytes written
+     * @throws \RuntimeException If callback execution fails
+     */
+    public function stream_write(string $data): int
+    {
+        if ($this->id === null) {
+            trigger_error('Stream not properly initialized', E_USER_WARNING);
+            return 0;
+        }
+
+        $callback = self::$callbacks[$this->id] ?? null;
+        if ($callback === null) {
+            trigger_error('Callback not found for stream', E_USER_WARNING);
+            return 0;
+        }
+
+        try {
+            $callback($data);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(
+                'Callback function failed during stream write: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+
+        $length = strlen($data);
+        $this->pos += $length;
+        return $length;
+    }
+
+    /**
+     * Get current position in stream.
+     *
+     * @return int Current position
+     */
+    public function stream_tell(): int
+    {
+        return $this->pos;
+    }
+
+    /**
+     * Check if stream has reached end of file.
+     *
+     * @return bool Always false for write-only streams
+     */
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Flush stream buffers.
+     *
+     * @return bool Always true (no buffering)
+     */
+    public function stream_flush(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Close the stream and clean up callback.
+     */
+    public function stream_close(): void
+    {
+        if ($this->id !== null) {
+            unset(self::$callbacks[$this->id]);
+            $this->id = null;
+        }
+    }
+
+    /**
+     * Get stream statistics.
+     *
+     * @return array<string, mixed> Stream statistics
+     */
+    public function stream_stat(): array
+    {
+        return [
+            'dev' => 0,
+            'ino' => 0,
+            'mode' => 0100666, // Regular file, read/write permissions
+            'nlink' => 1,
+            'uid' => 0,
+            'gid' => 0,
+            'rdev' => 0,
+            'size' => $this->pos,
+            'atime' => time(),
+            'mtime' => time(),
+            'ctime' => time(),
+            'blksize' => 4096,
+            'blocks' => ceil($this->pos / 4096),
+        ];
+    }
+
+    /**
+     * Read data from stream (not supported - write-only stream).
+     *
+     * @param int $count Number of bytes to read (required by interface, unused)
+     * @return string Always empty string
+     * @psalm-suppress UnusedParam $count is required by the stream wrapper interface
+     */
+    public function stream_read(int $count): string
+    {
+        trigger_error('Read operations not supported on callback streams', E_USER_WARNING);
+        return '';
+    }
+
+    /**
+     * Seek to position in stream (not supported).
+     *
+     * @param int $offset Offset to seek to (required by interface, unused)
+     * @param int $whence Seek mode (required by interface, unused)
+     * @return bool Always false
+     * @psalm-suppress UnusedParam $offset and $whence are required by the stream wrapper interface
+     */
+    public function stream_seek(int $offset, int $whence = SEEK_SET): bool
+    {
+        trigger_error('Seek operations not supported on callback streams', E_USER_WARNING);
+        return false;
+    }
+
+    /**
+     * Set options on stream (not supported).
+     *
+     * @param int $option Option to set (required by interface, unused)
+     * @param int $arg1 First argument (required by interface, unused)
+     * @param int $arg2 Second argument (required by interface, unused)
+     * @return bool Always false
+     * @psalm-suppress UnusedParam All parameters are required by the stream wrapper interface
+     */
+    public function stream_set_option(int $option, int $arg1, int $arg2): bool
+    {
+        return false;
+    }
+
+    /**
+     * Truncate stream (not supported).
+     *
+     * @param int $new_size New size (required by interface, unused)
+     * @return bool Always false
+     * @psalm-suppress UnusedParam $new_size is required by the stream wrapper interface
+     */
+    public function stream_truncate(int $new_size): bool
+    {
+        trigger_error('Truncate operations not supported on callback streams', E_USER_WARNING);
+        return false;
+    }
+}

--- a/test/CallbackOutputTest.php
+++ b/test/CallbackOutputTest.php
@@ -1,0 +1,200 @@
+<?php
+declare(strict_types=1);
+
+namespace ZipStream\Test;
+
+use PHPUnit\Framework\TestCase;
+use ZipStream\ZipStream;
+use ZipStream\Stream\CallbackStreamWrapper;
+use ZipArchive;
+
+final class CallbackOutputTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // Clean up any registered callbacks to prevent memory leaks in tests
+        CallbackStreamWrapper::cleanup();
+        parent::tearDown();
+    }
+
+    public function testDataIsForwardedToCallback(): void
+    {
+        $buf = '';
+        $zip = new ZipStream(
+            outputStream: CallbackStreamWrapper::open(
+                static function (string $chunk) use (&$buf): void { $buf .= $chunk; }
+            ),
+            sendHttpHeaders: false
+        );
+
+        $zip->addFile('hello.txt', 'Hello World');
+        $zip->finish();
+
+        $tmp = tmpfile();
+        fwrite($tmp, $buf);
+        rewind($tmp);
+
+        $meta = stream_get_meta_data($tmp);
+        $za   = new ZipArchive();
+        $za->open($meta['uri']);
+
+        $content = $za->getFromName('hello.txt');
+        $za->close();
+        fclose($tmp);
+
+        $this->assertSame('Hello World', $content);
+    }
+
+    public function testMultipleSimultaneousStreams(): void
+    {
+        $buf1 = '';
+        $buf2 = '';
+
+        $stream1 = CallbackStreamWrapper::open(
+            static function (string $chunk) use (&$buf1): void { $buf1 .= $chunk; }
+        );
+        $stream2 = CallbackStreamWrapper::open(
+            static function (string $chunk) use (&$buf2): void { $buf2 .= $chunk; }
+        );
+
+        $this->assertIsResource($stream1);
+        $this->assertIsResource($stream2);
+
+        fwrite($stream1, 'data1');
+        fwrite($stream2, 'data2');
+        fclose($stream1);
+        fclose($stream2);
+
+        $this->assertSame('data1', $buf1);
+        $this->assertSame('data2', $buf2);
+    }
+
+    public function testExceptionHandlingInCallback(): void
+    {
+        $stream = CallbackStreamWrapper::open(
+            static function (string $chunk): void {
+                throw new \RuntimeException('Callback error');
+            }
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Callback function failed during stream write: Callback error');
+
+        fwrite($stream, 'test data');
+    }
+
+    public function testLargeDataChunks(): void
+    {
+        $receivedChunks = [];
+        $totalBytes = 0;
+
+        $stream = CallbackStreamWrapper::open(
+            static function (string $chunk) use (&$receivedChunks, &$totalBytes): void {
+                $receivedChunks[] = strlen($chunk);
+                $totalBytes += strlen($chunk);
+            }
+        );
+
+        // Write large chunks of data
+        $largeData = str_repeat('x', 65536); // 64KB
+        fwrite($stream, $largeData);
+        fwrite($stream, $largeData);
+        fclose($stream);
+
+        $this->assertSame(131072, $totalBytes); // 128KB total
+        $this->assertNotEmpty($receivedChunks);
+        // Large data should be written (possibly in multiple chunks)
+        $this->assertGreaterThan(0, max($receivedChunks));
+    }
+
+    public function testStreamPositionTracking(): void
+    {
+        $stream = CallbackStreamWrapper::open(
+            static function (string $chunk): void { /* no-op */ }
+        );
+
+        $this->assertSame(0, ftell($stream));
+
+        fwrite($stream, 'hello');
+        $this->assertSame(5, ftell($stream));
+
+        fwrite($stream, ' world');
+        $this->assertSame(11, ftell($stream));
+
+        fclose($stream);
+    }
+
+    public function testInvalidModeRejection(): void
+    {
+        $stream = CallbackStreamWrapper::open(
+            static function (string $chunk): void { /* no-op */ }
+        );
+
+        // Close the stream first
+        fclose($stream);
+
+        // Try to open with read mode - should fail
+        $readStream = fopen('zipcb://invalid', 'rb');
+        $this->assertFalse($readStream);
+    }
+
+    public function testStreamStatistics(): void
+    {
+        $stream = CallbackStreamWrapper::open(
+            static function (string $chunk): void { /* no-op */ }
+        );
+
+        fwrite($stream, 'test data');
+
+        $stats = fstat($stream);
+        $this->assertIsArray($stats);
+        $this->assertSame(9, $stats['size']); // Length of 'test data'
+        $this->assertSame(0100666, $stats['mode']); // Regular file permissions
+
+        fclose($stream);
+    }
+
+    public function testProgressTracking(): void
+    {
+        $progress = [];
+        $totalBytes = 0;
+
+        $zip = new ZipStream(
+            outputStream: CallbackStreamWrapper::open(
+                static function (string $chunk) use (&$progress, &$totalBytes): void {
+                    $totalBytes += strlen($chunk);
+                    $progress[] = $totalBytes;
+                }
+            ),
+            sendHttpHeaders: false
+        );
+
+        $zip->addFile('file1.txt', 'Content 1');
+        $zip->addFile('file2.txt', 'Content 2');
+        $zip->finish();
+
+        $this->assertNotEmpty($progress);
+        $this->assertGreaterThan(0, $totalBytes);
+        $this->assertTrue(count($progress) > 1, 'Should have multiple progress updates');
+    }
+
+    public function testCallbackCleanupOnClose(): void
+    {
+        $callbackExecuted = false;
+
+        $stream = CallbackStreamWrapper::open(
+            static function (string $chunk) use (&$callbackExecuted): void {
+                $callbackExecuted = true;
+            }
+        );
+
+        fwrite($stream, 'test');
+        $this->assertTrue($callbackExecuted);
+
+        fclose($stream);
+
+        // After closing, callback should be cleaned up
+        // We can't directly test this, but the tearDown cleanup should work without issues
+        $this->assertTrue(true); // Placeholder assertion
+    }
+}


### PR DESCRIPTION
### Summary  
This PR introduces the `CallbackStreamWrapper`, a new stream wrapper (zipcb://) allowing ZIP output to be sent to any custom PHP callback function.

### Why
* Streaming simultaneously to multiple destinations (e.g., files, logs, browser).
* Real-time progress tracking during archive creation.
* Performing safe, byte-stream-level data transformations without temporary files.

Requested originally in #199.

### What changed
* **New class** `ZipStream\Stream\CallbackStreamWrapper` (`zipcb://` protocol).  
  `CallbackStreamWrapper::open(callable $cb)` returns a writable resource for the `outputStream` option.
* **Docs**: updated `README.md`, `guides/Options.rst`, `guides/StreamOutput.rst`.
* **Tests**: new `test/CallbackOutputTest.php` (data integrity, multi-stream, error handling, stats, large chunks, progress).


### Backward compatibility
No breaking changes. Existing code that passes a normal stream resource still works.

Closes #199