### PR TITLE
Fix directory local header size fields corrupted at offset >4 GB

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -202,10 +202,10 @@ final class File
             compressionMethod: $this->compressionMethod,
             lastModificationDateTime: $this->lastModificationDateTime,
             crc32UncompressedData: $this->crc,
-            compressedSize: $zip64Enabled
+            compressedSize: ($forceEnableZip64 || $this->compressedSize > 0xFFFFFFFF)
                 ? 0xFFFFFFFF
                 : $this->compressedSize,
-            uncompressedSize: $zip64Enabled
+            uncompressedSize: ($forceEnableZip64 || $this->uncompressedSize > 0xFFFFFFFF)
                 ? 0xFFFFFFFF
                 : $this->uncompressedSize,
             fileName: $this->fileName,

--- a/test/ZipStreamTest.php
+++ b/test/ZipStreamTest.php
@@ -549,12 +549,24 @@ class ZipStreamTest extends TestCase
             );
         }
 
+        $zip->addDirectory('mydir/');
+
         $zip->finish();
 
         $tmpDir = $this->validateAndExtractZip($this->tempfile);
 
         $files = $this->getRecursiveFileList($tmpDir);
         $this->assertSame(['sample0', 'sample1', 'sample2', 'sample3'], $files);
+
+        $this->assertFileDoesNotContain(
+            $this->tempfile,
+            PackField::pack(
+                new PackField(format: 'V', value: 0x00000000), // CRC-32 = 0 (directory)
+                new PackField(format: 'V', value: 0xFFFFFFFF), // compressedSize — bug sentinel
+                new PackField(format: 'V', value: 0xFFFFFFFF), // uncompressedSize — bug sentinel
+                new PackField(format: 'v', value: 6),          // filename length = strlen('mydir/')
+            )
+        );
     }
 
     #[Group('slow')]


### PR DESCRIPTION
Hello,

I'm using this wonderful library to create ZIPs that can sometimes contain thousands of directories and files.
Some of these ZIPs can reach 10GB.
I've been having issues with bigger ZIPs that were also saying "corrupted" when trying to open it on my computer.

I've been talking with Claude to try to understand what I was doing wrong, and after quite a lot, I think I found a bug when trying to add a directory when the zip is already >4GB.

I'll try to explain as clearly as possible.
I had to use Claude to help me explain with the proper technical terms, since I'm not super knowledgeable with the inner tech of zip.

Hopefully it makes sense, let me know if you need any more information.
Thanks!

## Problem

When building a ZIP archive larger than 4 GB that contains directory entries, any directory whose local file header starts past the 4 GB boundary ends up with corrupted size fields. 
Streaming ZIP readers (those that cannot seek back to the Central Directory) misread the directory's start offset (~4+ GB) as its file size.

## Root Cause

`addDirectory()` always passes `enableZeroHeader: false`, which means `forceEnableZip64` is always `false` for directory entries:
```php
// File.php, line 183
$forceEnableZip64 = $this->enableZeroHeader && $this->enableZip64;
// = false && true
```

When only `startOffset` overflows 4 GB (and not the sizes, which are always 0 for a directory), `buildZip64ExtraBlock()` correctly emits a ZIP64 extra block containing only `relativeHeaderOffset`.
However, `addFileHeader()` used `$zip64Enabled` as a proxy for "sizes need ZIP64", and since the extra block is non-empty, `$zip64Enabled = true`, causing both size fields in the local file header to be written as `0xFFFFFFFF`.

The result is a local file header that signals "look in ZIP64 extra for sizes" (via the `0xFFFFFFFF` sentinels), but the ZIP64 extra block only contains the offset value. A reader following the spec interprets the first 8 bytes of the ZIP64 extra as `originalSize`, reading the ~4 GB offset as the file size instead of 0.

## Proposed fix

In `addFileHeader()`, size fields in the local header should only use the `0xFFFFFFFF` sentinel when those sizes actually need ZIP64, not merely because the file's offset does:

```php
// Before
compressedSize: $zip64Enabled ? 0xFFFFFFFF : $this->compressedSize,
uncompressedSize: $zip64Enabled ? 0xFFFFFFFF : $this->uncompressedSize,

// After
compressedSize: ($forceEnableZip64 || $this->compressedSize > 0xFFFFFFFF) ? 0xFFFFFFFF : $this->compressedSize,
uncompressedSize: ($forceEnableZip64 || $this->uncompressedSize > 0xFFFFFFFF) ? 0xFFFFFFFF : $this->uncompressedSize,
```

`$forceEnableZip64` preserves the existing behavior for `enableZeroHeader=true` (streaming mode), where sizes genuinely are unknown upfront and must be written as placeholders.

## Script to reproduce

```php
<?php

require __DIR__ . '/vendor/autoload.php';

use ZipStream\CompressionMethod;
use ZipStream\OperationMode;
use ZipStream\ZipStream;

$zipPath = sys_get_temp_dir() . '/zipstream_bug_demo.zip';
$output  = fopen($zipPath, 'w+b');

$zip = new ZipStream(
    operationMode: OperationMode::SIMULATE_STRICT,
    outputStream: $output,
    enableZip64: true,
    defaultEnableZeroHeader: true,
    sendHttpHeaders: false,
);

// A ~4.5 GB file pushes the next entry past the 4 GB offset boundary.
$zip->addFileFromCallback(
    fileName: 'large.bin',
    callback: static function () { return fopen('/dev/zero', 'rb'); },
    compressionMethod: CompressionMethod::STORE,
    exactSize: 0x120000000,
);

// This directory entry lands at offset 0x120000053, which is > 4 GB.
$zip->addDirectory('mydir/');

$zip->finish();
$zip->executeSimulation();
fclose($output);

// The directory local file header starts at offset 0x120000057:
//   63 bytes  = large.bin local header (30 fixed + 9 filename + 20 ZIP64 extra + 4 Zs extra)
//   + 0x120000000 bytes = file data (STORE)
//   + 24 bytes = ZIP64 data descriptor
//
// compressedSize is at header offset +18, uncompressedSize at +22.
// Both must be 0 for a directory. Before the fix they are 0xFFFFFFFF.
$dirHeaderOffset = 0x120000057;

$f = fopen($zipPath, 'rb');
fseek($f, $dirHeaderOffset + 18);
$fields = unpack('Vcomp/Vuncomp', fread($f, 8));
fclose($f);

echo 'compressedSize  : ' . $fields['comp']   . ($fields['comp']   === 0xFFFFFFFF ? ' <-- BUG' : ' (OK)') . "\n";
echo 'uncompressedSize: ' . $fields['uncomp'] . ($fields['uncomp'] === 0xFFFFFFFF ? ' <-- BUG' : ' (OK)') . "\n";

unlink($zipPath);
```

Output
```
# Before fix:
compressedSize  : 4294967295 <-- BUG
uncompressedSize: 4294967295 <-- BUG

# After fix:
compressedSize  : 0 (OK)
uncompressedSize: 0 (OK)
```