### PR TITLE
Cast compressedSize to int for consistency

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -204,7 +204,7 @@ final class File
             crc32UncompressedData: $this->crc,
             compressedSize: ($forceEnableZip64 || $this->compressedSize > 0xFFFFFFFF)
                 ? 0xFFFFFFFF
-                : $this->compressedSize,
+                : (int)$this->compressedSize,
             uncompressedSize: ($forceEnableZip64 || $this->uncompressedSize > 0xFFFFFFFF)
                 ? 0xFFFFFFFF
                 : $this->uncompressedSize,


### PR DESCRIPTION
Run time we are getting float value which eventually breaks the zip compression and user gets the corrupted zip file which user can not open.

Please go the the `Preview` tab and select the appropriate sub-template:

* [🐞 Failing Test](?expand=1&template=FAILING_TEST.md)
* [🐞 Bug Fix](?expand=1&template=FIX.md)
* [⚙ Improvement](?expand=1&template=IMPROVEMENT.md)
* [🎉 New Feature](?expand=1&template=NEW_FEATURE.md)
