### PR TITLE
Cleanup the composer archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,16 @@
 *.yml      text eol=lf
 *.xml      text eol=lf
 
-/.github          export-ignore
-/.gitattributes   export-ignore
-/.gitignore       export-ignore
+/.github                export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.phive                 export-ignore
+/.phpdoc                export-ignore
+/guides                 export-ignore
+/test                   export-ignore
+/.editorconfig          export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/.tool-versions         export-ignore
+/phpdoc.dist.xml        export-ignore
+/phpunit.xml.dist       export-ignore
+/psalm.xml              export-ignore


### PR DESCRIPTION
<!---
name: ⚙ Improvement
about: You have some improvement to make ZipStream-PHP better?
labels: enhancement
--->

I removed all the non production files from the composer archive, this is more lightweight for servers.
Servers do not need dev files. And this change is what most of the projects do nowdays
